### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ allprojects {
     apply from: "${rootProject.projectDir}/maven.gradle"
 
 	repositories {
-		maven { url "http://repo.springsource.org/libs-milestone" }
+		maven { url "https://repo.springsource.org/libs-milestone" }
 	}
 
 	dependencies {
@@ -141,11 +141,11 @@ configure(rootProject) {
         options.overview = 'docs/api/overview.html'
         options.splitIndex = true
         options.links(
-           "http://download.oracle.com/javase/6/docs/api",
-           "http://static.springframework.org/spring/docs/3.1.x/javadoc-api",
-           "http://static.springframework.org/spring-hadoop/docs/current/api",
-           "http://static.springsource.org/spring-batch/apidocs/",
-           "http://hadoop.apache.org/common/docs/current/api/"
+           "https://download.oracle.com/javase/6/docs/api",
+           "https://docs.spring.io/spring/docs/3.1.x/javadoc-api",
+           "https://docs.spring.io/spring-hadoop/docs/current/api",
+           "https://docs.spring.io/spring-batch/apidocs/",
+           "https://hadoop.apache.org/common/docs/current/api/"
         )
         source subprojects.collect { project ->
             project.sourceSets.main.allJava

--- a/maven.gradle
+++ b/maven.gradle
@@ -34,17 +34,17 @@ def customizePom(pom, gradleProject) {
 			url = 'https://github.com/SpringSource/impala'
 			organization {
 				name = 'SpringSource'
-				url = 'http://springsource.org/impala'
+				url = 'https://www.spring.io'
 			}
 			licenses {
 				license {
 					name 'The Apache Software License, Version 2.0'
-					url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+					url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 					distribution 'repo'
 				}
 			}
             scm {
-                url = 'http://github.com/SpringSource/impala'
+                url = 'https://github.com/SpringSource/impala'
                 connection = 'scm:git:git://github.com/SpringSource/impala'
                 developerConnection = 'scm:git:git://github.com/SpringSource/impala'
             }

--- a/samples/simple/build.gradle
+++ b/samples/simple/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'java'
 apply plugin: 'eclipse'
 
 repositories {
-	maven { url "http://repo.springsource.org/libs-snapshot" }
+	maven { url "https://repo.springsource.org/libs-snapshot" }
 	maven { url "http://spring-roo-repository.springsource.org/release" }
 }
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://spring-roo-repository.springsource.org/release (404) migrated to:  
  http://spring-roo-repository.springsource.org/release ([https](https://spring-roo-repository.springsource.org/release) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://springsource.org/impala (302) migrated to:  
  https://www.spring.io ([https](https://springsource.org/impala) result SSLHandshakeException).
* http://hadoop.apache.org/common/docs/current/api/ (404) migrated to:  
  https://hadoop.apache.org/common/docs/current/api/ ([https](https://hadoop.apache.org/common/docs/current/api/) result 404).

## Fixed Success 
These URLs were fixed successfully.

* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://static.springsource.org/spring-batch/apidocs/ (301) migrated to:  
  https://docs.spring.io/spring-batch/apidocs/ ([https](https://static.springsource.org/spring-batch/apidocs/) result 301).
* http://static.springframework.org/spring-hadoop/docs/current/api (301) migrated to:  
  https://docs.spring.io/spring-hadoop/docs/current/api ([https](https://static.springframework.org/spring-hadoop/docs/current/api) result 301).
* http://static.springframework.org/spring/docs/3.1.x/javadoc-api (301) migrated to:  
  https://docs.spring.io/spring/docs/3.1.x/javadoc-api ([https](https://static.springframework.org/spring/docs/3.1.x/javadoc-api) result 301).
* http://github.com/SpringSource/impala migrated to:  
  https://github.com/SpringSource/impala ([https](https://github.com/SpringSource/impala) result 301).
* http://repo.springsource.org/libs-milestone migrated to:  
  https://repo.springsource.org/libs-milestone ([https](https://repo.springsource.org/libs-milestone) result 301).
* http://repo.springsource.org/libs-snapshot migrated to:  
  https://repo.springsource.org/libs-snapshot ([https](https://repo.springsource.org/libs-snapshot) result 301).
* http://download.oracle.com/javase/6/docs/api migrated to:  
  https://download.oracle.com/javase/6/docs/api ([https](https://download.oracle.com/javase/6/docs/api) result 302).