### PR TITLE
URL Cleanup

### DIFF
--- a/docs/info/license.txt
+++ b/docs/info/license.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugin-common/src/main/java/org/springframework/data/hadoop/impala/common/ConfigurationAware.java
+++ b/plugin-common/src/main/java/org/springframework/data/hadoop/impala/common/ConfigurationAware.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugin-common/src/main/java/org/springframework/data/hadoop/impala/common/ConfigurationCommands.java
+++ b/plugin-common/src/main/java/org/springframework/data/hadoop/impala/common/ConfigurationCommands.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugin-common/src/main/java/org/springframework/data/hadoop/impala/common/ConfigurationModifiedEvent.java
+++ b/plugin-common/src/main/java/org/springframework/data/hadoop/impala/common/ConfigurationModifiedEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugin-common/src/main/java/org/springframework/data/hadoop/impala/common/util/SecurityUtil.java
+++ b/plugin-common/src/main/java/org/springframework/data/hadoop/impala/common/util/SecurityUtil.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugin-common/src/main/java/org/springframework/data/hadoop/impala/provider/ImpalaPluginBannerProvider.java
+++ b/plugin-common/src/main/java/org/springframework/data/hadoop/impala/provider/ImpalaPluginBannerProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugin-common/src/main/java/org/springframework/data/hadoop/impala/provider/ImpalaPluginHistoryFileNameProvider.java
+++ b/plugin-common/src/main/java/org/springframework/data/hadoop/impala/provider/ImpalaPluginHistoryFileNameProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugin-common/src/main/java/org/springframework/data/hadoop/impala/provider/ImpalaPluginPromptProvider.java
+++ b/plugin-common/src/main/java/org/springframework/data/hadoop/impala/provider/ImpalaPluginPromptProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugin-common/src/test/java/org/springframework/data/hadoop/impala/provider/SpringHadoopAdminBannerProviderTest.java
+++ b/plugin-common/src/test/java/org/springframework/data/hadoop/impala/provider/SpringHadoopAdminBannerProviderTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugin-common/src/test/java/org/springframework/data/hadoop/impala/provider/SpringHadoopAdminHistoryFileNameProviderTest.java
+++ b/plugin-common/src/test/java/org/springframework/data/hadoop/impala/provider/SpringHadoopAdminHistoryFileNameProviderTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugin-common/src/test/java/org/springframework/data/hadoop/impala/provider/SpringHadoopAdminPromptProviderTest.java
+++ b/plugin-common/src/test/java/org/springframework/data/hadoop/impala/provider/SpringHadoopAdminPromptProviderTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugin-hdfs/src/main/java/org/springframework/data/hadoop/impala/hdfs/FsShellCommands.java
+++ b/plugin-hdfs/src/main/java/org/springframework/data/hadoop/impala/hdfs/FsShellCommands.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugin-hdfs/src/test/java/org/springframework/data/hadoop/impala/hdfs/FsShellCommandsTest.java
+++ b/plugin-hdfs/src/test/java/org/springframework/data/hadoop/impala/hdfs/FsShellCommandsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugin-hive/src/main/java/org/springframework/data/hadoop/impala/hive/HiveCommands.java
+++ b/plugin-hive/src/main/java/org/springframework/data/hadoop/impala/hive/HiveCommands.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugin-mapreduce/src/main/java/org/springframework/data/hadoop/impala/mapreduce/MapReduceCommands.java
+++ b/plugin-mapreduce/src/main/java/org/springframework/data/hadoop/impala/mapreduce/MapReduceCommands.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugin-mapreduce/src/test/java/org/springframework/data/hadoop/impala/mapreduce/MapReduceCommandsTest.java
+++ b/plugin-mapreduce/src/test/java/org/springframework/data/hadoop/impala/mapreduce/MapReduceCommandsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugin-pig/src/main/java/org/springframework/data/hadoop/impala/pig/PigCommands.java
+++ b/plugin-pig/src/main/java/org/springframework/data/hadoop/impala/pig/PigCommands.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugin-r/src/main/java/org/springframework/data/hadoop/impala/r/RCommands.java
+++ b/plugin-r/src/main/java/org/springframework/data/hadoop/impala/r/RCommands.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 18 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).